### PR TITLE
Update datasets per MLELO's request

### DIFF
--- a/queries/public/pend_to_ww.sql
+++ b/queries/public/pend_to_ww.sql
@@ -1,0 +1,36 @@
+WITH
+    points_per_player AS (
+        SELECT
+            SUM(ed.scrim_points) as points,
+            ed.player_id
+        FROM
+            mledb.eligibility_data ed
+        WHERE
+            ed.updated_at > NOW () - INTERVAL '30 days'
+        GROUP BY
+            2
+    ),
+    names_teams_with_points AS (
+        SELECT
+            mle_p.mleid,
+            mle_p.name,
+            mle_p.team_name,
+            ppp.player_id,
+            ppp.points
+        FROM
+            mledb.player mle_p
+            INNER JOIN points_per_player ppp ON ppp.player_id = mle_p.id
+    )
+SELECT
+    *
+FROM
+    names_teams_with_points ntwp
+WHERE ntwp.points >= 30
+AND ntwp.team_name = 'Pend'
+
+
+
+
+    -- SELECT ed.scrim_points as points, ed.player_id, ed.updated_at FROM mledb.eligibility_data ed
+    -- WHERE ed.updated_at > NOW() - INTERVAL '30 days'
+    -- AND ed.player_id = 7939

--- a/queries/public/players.sql
+++ b/queries/public/players.sql
@@ -8,7 +8,7 @@ SELECT
     mle_p.role as slot,
     mle_p.mleid as mle_id,
     mle_p.id as mle_player_id,
-    mle_p.discord_id as discord_id,
+    mle_p.discord_id as discord_id
 FROM
     sprocket.player p
     INNER JOIN sprocket.member sm ON sm.id = p."memberId"

--- a/queries/public/players.sql
+++ b/queries/public/players.sql
@@ -1,11 +1,19 @@
-SELECT p."memberId" as member_id,
-       mp.name,
-       p.salary,
-       gsgp.description  as skill_group,
-       mle_p.team_name   as franchise,
-       mle_p.role        as slot
-FROM sprocket.player p
-         INNER JOIN sprocket.game_skill_group_profile gsgp ON p."skillGroupId" = gsgp."skillGroupId"
-         INNER JOIN sprocket.member_profile mp ON p."memberId" = mp."memberId"
-         INNER JOIN mledb_bridge.player_to_player bridge_ptp ON bridge_ptp."sprocketPlayerId" = p.id
-         INNER JOIN mledb.player mle_p ON bridge_ptp."mledPlayerId" = mle_p.id
+SELECT
+    mp.name,
+    p.salary,
+    p.id as sprocket_player_id,
+    p."memberId" as member_id,
+    gsgp.description as skill_group,
+    mle_p.team_name as franchise,
+    mle_p.role as slot,
+    mle_p.mleid as mle_id,
+    mle_p.id as mle_player_id,
+    mle_p.discord_id as discord_id,
+FROM
+    sprocket.player p
+    INNER JOIN sprocket.member sm ON sm.id = p."memberId"
+    INNER JOIN sprocket.user su ON su.id = sm."userId"
+    INNER JOIN sprocket.game_skill_group_profile gsgp ON p."skillGroupId" = gsgp."skillGroupId"
+    INNER JOIN sprocket.member_profile mp ON p."memberId" = mp."memberId"
+    INNER JOIN mledb_bridge.player_to_player bridge_ptp ON bridge_ptp."sprocketPlayerId" = p.id
+    INNER JOIN mledb.player mle_p ON bridge_ptp."mledPlayerId" = mle_p.id

--- a/queries/public/ww_30+.sql
+++ b/queries/public/ww_30+.sql
@@ -1,0 +1,29 @@
+WITH
+    points_per_player AS (
+        SELECT
+            SUM(ed.scrim_points) as points,
+            ed.player_id
+        FROM
+            mledb.eligibility_data ed
+        WHERE
+            ed.updated_at > NOW () - INTERVAL '30 days'
+        GROUP BY
+            2
+    ),
+    names_teams_with_points AS (
+        SELECT
+            mle_p.mleid,
+            mle_p.name,
+            mle_p.team_name,
+            ppp.player_id,
+            ppp.points
+        FROM
+            mledb.player mle_p
+            INNER JOIN points_per_player ppp ON ppp.player_id = mle_p.id
+    )
+SELECT
+    *
+FROM
+    names_teams_with_points ntwp
+WHERE ntwp.points >= 30
+AND ntwp.team_name = 'Waivers'

--- a/queries/public/ww_lt_30.sql
+++ b/queries/public/ww_lt_30.sql
@@ -1,0 +1,29 @@
+WITH
+    points_per_player AS (
+        SELECT
+            SUM(ed.scrim_points) as points,
+            ed.player_id
+        FROM
+            mledb.eligibility_data ed
+        WHERE
+            ed.updated_at > NOW () - INTERVAL '30 days'
+        GROUP BY
+            2
+    ),
+    names_teams_with_points AS (
+        SELECT
+            mle_p.mleid,
+            mle_p.name,
+            mle_p.team_name,
+            ppp.player_id,
+            ppp.points
+        FROM
+            mledb.player mle_p
+            INNER JOIN points_per_player ppp ON ppp.player_id = mle_p.id
+    )
+SELECT
+    *
+FROM
+    names_teams_with_points ntwp
+WHERE ntwp.points < 30
+AND ntwp.team_name = 'Waivers'


### PR DESCRIPTION
Modified:
players.sql - Added Sprocket User and Player IDs, MLEID and discord ID

Added:
pend_to_ww.sql - list of `Pend` players who have > 30 scrim points, and are thus eligible for the Waiver Wire
ww_30+.sql - list of current WW who are eligible to be picked up this week
ww_lt_30.sql - the opposite, WW who aren't eligible. 