### PR TITLE
Add NCP to S18 rounds query

### DIFF
--- a/queries/public/s18/rounds_s18.sql
+++ b/queries/public/s18/rounds_s18.sql
@@ -4,7 +4,7 @@ select
     r.id as round_id,
 
     -- Get home team name
-    fph.title as home,
+    fph.title as "Home",
 
     -- Get home goals from team stats or 0 if NCP
     CASE
@@ -12,10 +12,10 @@ select
         m."invalidationId" IS NOT NULL OR
         tslh.stats IS NULL THEN 0
         ELSE (tslh.stats->'stats'->'core'->'goals')::INT
-    END as home_goals,
+    END as "Home Goals",
 
     -- Get away team name
-    fpa.title as away,
+    fpa.title as "Away",
 
     -- Get away goals from team stats or 0 if NCP
     CASE
@@ -23,7 +23,7 @@ select
         m."invalidationId" IS NOT NULL OR
         tsla.stats IS NULL THEN 0
         ELSE (tsla.stats->'stats'->'core'->'goals')::INT
-    END as away_goals,
+    END as "Away Goals",
 
     -- Get winner team name
     CASE

--- a/queries/public/s18/rounds_s18.sql
+++ b/queries/public/s18/rounds_s18.sql
@@ -1,36 +1,36 @@
 select
-	-- Get serie and game id
+    -- Get serie and game id
     m.id as match_id,
     r.id as round_id,
-    
+
     -- Get home team name
     fph.title as home,
-    
+
     -- Get home goals from team stats or 0 if NCP
     CASE
         WHEN r."invalidationId" IS NOT NULL OR
         m."invalidationId" IS NOT NULL OR
         tslh.stats IS NULL THEN 0
-		ELSE (tslh.stats->'stats'->'core'->'goals')::INT
+        ELSE (tslh.stats->'stats'->'core'->'goals')::INT
     END as home_goals,
-    
+
     -- Get away team name
     fpa.title as away,
-    
+
     -- Get away goals from team stats or 0 if NCP
-    CASE 
+    CASE
         WHEN r."invalidationId" IS NOT NULL OR
         m."invalidationId" IS NOT NULL OR
         tsla.stats IS NULL THEN 0
-		ELSE (tsla.stats->'stats'->'core'->'goals')::INT
+        ELSE (tsla.stats->'stats'->'core'->'goals')::INT
     END as away_goals,
-    
+
     -- Get winner team name
     CASE
         WHEN r."homeWon" THEN fph.title
         ELSE fpa.title
     END as winner,
-    
+
     -- If invalidation is filled in either serie or game, consider this game NCP
     r."invalidationId" IS NOT NULL OR m."invalidationId" IS NOT NULL as is_ncp
 
@@ -51,5 +51,5 @@ where sg."parentGroupId" = 291
 
 -- Order by series then individual games id
 order by
-	m.id,
-	r.id
+    m.id,
+    r.id

--- a/queries/public/s18/rounds_s18.sql
+++ b/queries/public/s18/rounds_s18.sql
@@ -1,19 +1,55 @@
 select
+	-- Get serie and game id
     m.id as match_id,
     r.id as round_id,
-    fph.title as "Home",
-    tslh.stats->'stats'->'core'->'goals' as "Home Goals",
-    fpa.title as "Away",
-    tsla.stats->'stats'->'core'->'goals' as "Away Goals"
+    
+    -- Get home team name
+    fph.title as home,
+    
+    -- Get home goals from team stats or 0 if NCP
+    CASE
+        WHEN r."invalidationId" IS NOT NULL OR
+        m."invalidationId" IS NOT NULL OR
+        tslh.stats IS NULL THEN 0
+		ELSE (tslh.stats->'stats'->'core'->'goals')::INT
+    END as home_goals,
+    
+    -- Get away team name
+    fpa.title as away,
+    
+    -- Get away goals from team stats or 0 if NCP
+    CASE 
+        WHEN r."invalidationId" IS NOT NULL OR
+        m."invalidationId" IS NOT NULL OR
+        tsla.stats IS NULL THEN 0
+		ELSE (tsla.stats->'stats'->'core'->'goals')::INT
+    END as away_goals,
+    
+    -- Get winner team name
+    CASE
+        WHEN r."homeWon" THEN fph.title
+        ELSE fpa.title
+    END as winner,
+    
+    -- If invalidation is filled in either serie or game, consider this game NCP
+    r."invalidationId" IS NOT NULL OR m."invalidationId" IS NOT NULL as is_ncp
 
 from sprocket.round as r
-inner join sprocket.match m on m.id = r."matchId"
+inner join sprocket."match" m on m.id = r."matchId" -- match in quotation to avoid syntax warning
 inner join sprocket.match_parent mp on mp.id = m."matchParentId"
 inner join sprocket.schedule_fixture sf on sf.id = mp."fixtureId"
 inner join sprocket.schedule_group sg on sg.id = sf."scheduleGroupId"
 inner join sprocket.franchise_profile fph on sf."homeFranchiseId" = fph."franchiseId"
 inner join sprocket.franchise_profile fpa on sf."awayFranchiseId" = fpa."franchiseId"
-inner join sprocket.team_stat_line tslh on (tslh."roundId" = r.id and tslh."teamName" = fph.title)
-inner join sprocket.team_stat_line tsla on (tsla."roundId" = r.id and tsla."teamName" = fpa.title)
 
+-- We want to add the team stats if they exist, so left join
+left join sprocket.team_stat_line tslh on (tslh."roundId" = r.id and tslh."teamName" = fph.title)
+left join sprocket.team_stat_line tsla on (tsla."roundId" = r.id and tsla."teamName" = fpa.title)
+
+-- Season 18 ID is 291
 where sg."parentGroupId" = 291
+
+-- Order by series then individual games id
+order by
+	m.id,
+	r.id


### PR DESCRIPTION
- Check if the invalidation id is filled. Meaning a NCP.
- Stats line are now LEFT JOIN instead of INNER JOIN, meaning rounds without stats like NCP from a serie will still be there.
- IF NCP, clear the home/away goal count to 0.
- Because NCP makes goals to 0, added an explicit winner column.
- Query now returns ordered by match ID then round ID.
- Renamed columns
- Added comments for future reference