### PR TITLE
Change in logic for scrim eligibilty

### DIFF
--- a/queries/public/eligibility_data.sql
+++ b/queries/public/eligibility_data.sql
@@ -7,5 +7,6 @@ SELECT
 FROM
     sprocket.eligibility_data ed
 WHERE
-    ed."createdAt" AT TIME ZONE 'UTC' AT TIME ZONE 'America/New_York' >= DATE(NOW() AT TIME ZONE 'America/New_York') - INTERVAL '30 DAYS'  -- Step 1: go back 30 days
-    - ((EXTRACT(DOW FROM (DATE(NOW() AT TIME ZONE 'America/New_York') - INTERVAL '30 DAYS'))::int + 6) % 7) * INTERVAL '1 DAY' -- Step 2: go back to first Monday before 30 days
+    ed."createdAt" AT TIME ZONE 'UTC' AT TIME ZONE 'America/New_York' >= DATE(NOW() AT TIME ZONE 'America/New_York')
+    - ((EXTRACT(DOW FROM DATE(NOW() AT TIME ZONE 'America/New_York'))::int + 6) % 7) * INTERVAL '1 DAY' -- Step 1: go back to this Monday
+    - INTERVAL '30 DAYS' -- Step 2: go back 30 days from this Monday


### PR DESCRIPTION
This will fix the current logic error where we go back 30 days then find the Monday. Instead we swap that logic and go back to our current Monday then go back 30 days.