### PR TITLE
Add Trackmania only players to all_the_ids

### DIFF
--- a/queries/public/all_the_ids.sql
+++ b/queries/public/all_the_ids.sql
@@ -12,4 +12,4 @@ from
   inner join sprocket.player p on p."memberId" = m.id
   inner join sprocket.member_profile mp on mp."memberId" = m.id
   inner join sprocket.user_authentication_account uaa on uaa."userId" = u.id
-  inner join mledb.player mlep on mlep.discord_id = uaa."accountId";
+  left join mledb.player mlep on mlep.discord_id = uaa."accountId";

--- a/queries/public/report_cards/match_report_cards.md
+++ b/queries/public/report_cards/match_report_cards.md
@@ -1,0 +1,11 @@
+---
+examples:
+  - title: Match report cards for a team
+    query: |
+      SELECT * FROM %file WHERE home_team = 'Ducks' OR away_team = 'Ducks';
+  - title: Match report cards for a player
+    query: |
+      SELECT * FROM %file WHERE player_name = 'ExamplePlayer';
+---
+
+Match report card assets (one row per report-card player). Includes home/away teams, league/mode metadata, and a public image URL.

--- a/queries/public/report_cards/match_report_cards.sql
+++ b/queries/public/report_cards/match_report_cards.sql
@@ -1,0 +1,54 @@
+WITH
+  settings AS (
+    SELECT
+      COALESCE(
+        NULLIF(
+          current_setting('app.report_cards_base_url', true),
+          ''
+        ),
+        'https://sprocket-image-gen-main-1.nyc3.digitaloceanspaces.com'
+      ) AS base_url
+  ),
+  report_cards AS (
+    SELECT
+      rca.id AS report_card_id,
+      rca."sprocketId" AS match_id,
+      rca."legacyId" AS legacy_series_id,
+      rca."organizationId" AS organization_id,
+      rca."createdAt" AS generated_at,
+      rca."minioKey" AS minio_key
+    FROM
+      sprocket.report_card_asset rca
+    WHERE
+      rca.type = 'MATCH'
+  ),
+  series_info AS (
+    SELECT
+      s.id AS legacy_series_id,
+      s.league AS league,
+      s.mode AS game_mode,
+      f.home_name AS home_team,
+      f.away_name AS away_team
+    FROM
+      mledb.series s
+      LEFT JOIN mledb.fixture f ON f.id = s.fixture_id
+  )
+SELECT DISTINCT
+  rc.report_card_id,
+  rc.match_id,
+  rc.legacy_series_id,
+  rc.organization_id,
+  rc.generated_at,
+  si.league,
+  si.game_mode,
+  si.home_team,
+  si.away_team,
+  p.name AS player_name,
+  CONCAT(settings.base_url, '/', rc.minio_key) AS report_card_url
+FROM
+  report_cards rc
+  JOIN settings ON true
+  LEFT JOIN series_info si ON si.legacy_series_id = rc.legacy_series_id
+  LEFT JOIN mledb.series_replay sr ON sr.series_id = rc.legacy_series_id
+  LEFT JOIN mledb.player_stats_core psc ON psc.replay_id = sr.id
+  LEFT JOIN mledb.player p ON p.id = psc.player_id;

--- a/queries/public/report_cards/scrim_report_cards.md
+++ b/queries/public/report_cards/scrim_report_cards.md
@@ -1,0 +1,11 @@
+---
+examples:
+  - title: Scrim report cards for a player
+    query: |
+      SELECT * FROM %file WHERE player_name = 'ExamplePlayer';
+  - title: Scrim report cards for a league
+    query: |
+      SELECT * FROM %file WHERE league = 'CL';
+---
+
+Scrim report card assets (one row per report-card player). Includes league/mode metadata and a public image URL.

--- a/queries/public/report_cards/scrim_report_cards.sql
+++ b/queries/public/report_cards/scrim_report_cards.sql
@@ -1,0 +1,55 @@
+WITH
+  settings AS (
+    SELECT
+      COALESCE(
+        NULLIF(
+          current_setting('app.report_cards_base_url', true),
+          ''
+        ),
+        'https://sprocket-image-gen-main-1.nyc3.digitaloceanspaces.com'
+      ) AS base_url
+  ),
+  report_cards AS (
+    SELECT
+      rca.id AS report_card_id,
+      rca."sprocketId" AS scrim_id,
+      rca."legacyId" AS legacy_scrim_id,
+      rca."scrimUuid" AS scrim_uuid,
+      rca."organizationId" AS organization_id,
+      rca."createdAt" AS generated_at,
+      rca."minioKey" AS minio_key,
+      UNNEST(rca."userIds") AS user_id
+    FROM
+      sprocket.report_card_asset rca
+    WHERE
+      rca.type = 'SCRIM'
+  ),
+  member_names AS (
+    SELECT
+      m."userId" AS user_id,
+      m."organizationId" AS organization_id,
+      mp.name AS player_name
+    FROM
+      sprocket.member m
+      LEFT JOIN sprocket.member_profile mp ON mp."memberId" = m.id
+  )
+SELECT
+  rc.report_card_id,
+  rc.scrim_id,
+  rc.legacy_scrim_id,
+  rc.scrim_uuid,
+  rc.organization_id,
+  rc.generated_at,
+  rc.user_id,
+  COALESCE(mn.player_name, 'Unknown') AS player_name,
+  sc.type AS scrim_type,
+  sc.mode AS scrim_mode,
+  se.league AS league,
+  CONCAT(settings.base_url, '/', rc.minio_key) AS report_card_url
+FROM
+  report_cards rc
+  JOIN settings ON true
+  LEFT JOIN member_names mn ON mn.user_id = rc.user_id
+  AND mn.organization_id = rc.organization_id
+  LEFT JOIN mledb.scrim sc ON sc.id = rc.legacy_scrim_id
+  LEFT JOIN mledb.series se ON se.scrim_id = rc.legacy_scrim_id;


### PR DESCRIPTION
The inner join on mledb.player was excluding them, because TM only players don't get an MLEDB player created for them, we only do that for RL players (check core/src/franchise/player/player.service.ts over in sprocket for the code).