### PR TITLE
feature: add Trackmania public dataset queries

### DIFF
--- a/queries/public/trackmania/eligibility.sql
+++ b/queries/public/trackmania/eligibility.sql
@@ -1,0 +1,26 @@
+SELECT
+  ed.id AS eligibility_id,
+  ed."matchParentId" AS match_parent_id,
+  ed."playerId" AS sprocket_player_id,
+  lp.id AS local_player_id,
+  lp.discord_id,
+  lp.discord_username,
+  lp.member_id,
+  s.id AS local_scrim_id,
+  s.scrim_uid,
+  s.sprocket_match_id,
+  mp."fixtureId" AS fixture_id,
+  ed.points
+FROM
+  sprocket.eligibility_data ed
+  JOIN sprocket.player sp ON sp.id = ed."playerId"
+  JOIN sprocket.game_skill_group gsg ON gsg.id = sp."skillGroupId"
+  JOIN sprocket.game g ON g.id = gsg."gameId"
+  LEFT JOIN trackmania.players lp ON lp.sprocket_player_id = sp.id
+  LEFT JOIN trackmania.scrims s ON s.sprocket_match_parent_id = ed."matchParentId"
+  LEFT JOIN sprocket.match_parent mp ON mp.id = ed."matchParentId"
+WHERE
+  g.title = 'Trackmania'
+ORDER BY
+  ed."matchParentId" DESC,
+  lp.discord_username;

--- a/queries/public/trackmania/elo_history.sql
+++ b/queries/public/trackmania/elo_history.sql
@@ -1,0 +1,26 @@
+SELECT
+  eh.id AS elo_history_id,
+  eh.player_id AS local_player_id,
+  p.discord_id,
+  p.discord_username,
+  p.sprocket_player_id,
+  p.member_id,
+  eh.scrim_id AS local_scrim_id,
+  s.scrim_uid,
+  s.sprocket_match_parent_id,
+  s.sprocket_match_id,
+  mp."fixtureId" AS fixture_id,
+  s.league,
+  eh.old_rating,
+  eh.new_rating,
+  eh.change_amount,
+  eh.created_at
+FROM
+  trackmania.elo_history eh
+  JOIN trackmania.players p ON p.id = eh.player_id
+  JOIN trackmania.scrims s ON s.id = eh.scrim_id
+  LEFT JOIN sprocket.match_parent mp ON mp.id = s.sprocket_match_parent_id
+ORDER BY
+  eh.created_at DESC,
+  eh.scrim_id,
+  p.discord_username;

--- a/queries/public/trackmania/elo_ratings.sql
+++ b/queries/public/trackmania/elo_ratings.sql
@@ -1,0 +1,19 @@
+SELECT
+  er.id AS elo_rating_id,
+  er.player_id AS local_player_id,
+  p.discord_id,
+  p.discord_username,
+  p.sprocket_player_id,
+  p.member_id,
+  er.league,
+  er.rating,
+  er.wins,
+  er.losses,
+  er.updated_at
+FROM
+  trackmania.elo_ratings er
+  JOIN trackmania.players p ON p.id = er.player_id
+ORDER BY
+  er.league,
+  er.rating DESC,
+  p.discord_username;

--- a/queries/public/trackmania/matches.sql
+++ b/queries/public/trackmania/matches.sql
@@ -1,0 +1,38 @@
+SELECT
+  s.id AS local_scrim_id,
+  s.scrim_uid,
+  s.league,
+  s.status,
+  s.match_type,
+  s.winner_team,
+  s.elo_processed,
+  s.sprocket_match_parent_id,
+  s.sprocket_match_id,
+  mp."fixtureId" AS fixture_id,
+  sf."homeFranchiseId" AS home_franchise_id,
+  home.name AS home_franchise_name,
+  sf."awayFranchiseId" AS away_franchise_id,
+  away.name AS away_franchise_name,
+  sg.id AS schedule_group_id,
+  sg.name AS schedule_group_name,
+  gsg.id AS skill_group_id,
+  COALESCE(gsgp.description, gsgp.code) AS skill_group,
+  gm.name AS game_mode,
+  s.created_at,
+  s.completed_at
+FROM
+  trackmania.scrims s
+  LEFT JOIN sprocket.match_parent mp ON mp.id = s.sprocket_match_parent_id
+  LEFT JOIN sprocket.schedule_fixture sf ON sf.id = mp."fixtureId"
+  LEFT JOIN sprocket.franchise home ON home.id = sf."homeFranchiseId"
+  LEFT JOIN sprocket.franchise away ON away.id = sf."awayFranchiseId"
+  LEFT JOIN sprocket.schedule_group sg ON sg.id = sf."scheduleGroupId"
+  LEFT JOIN sprocket.game_skill_group gsg ON gsg.id = sf."skillGroupId"
+  LEFT JOIN sprocket.game g ON g.id = gsg."gameId"
+  LEFT JOIN sprocket.game_skill_group_profile gsgp ON gsgp."skillGroupId" = gsg.id
+  LEFT JOIN sprocket.game_mode gm ON gm.id = sf."gameModeId"
+WHERE
+  g.title = 'Trackmania'
+  OR s.sprocket_match_parent_id IS NOT NULL
+ORDER BY
+  s.created_at DESC;

--- a/queries/public/trackmania/player_stats.sql
+++ b/queries/public/trackmania/player_stats.sql
@@ -1,0 +1,40 @@
+SELECT
+  mps.id AS stat_id,
+  mps.scrim_id AS local_scrim_id,
+  s.scrim_uid,
+  s.sprocket_match_parent_id,
+  s.sprocket_match_id,
+  mp."fixtureId" AS fixture_id,
+  mps.map_id AS local_map_id,
+  maps.uid AS map_uid,
+  maps.name AS map_name,
+  mps.player_id AS local_player_id,
+  p.discord_id,
+  p.discord_username,
+  p.sprocket_player_id,
+  p.member_id,
+  p.platform_account_ids,
+  mps.team_id,
+  mps.points,
+  mps.is_finished,
+  mps.is_dnf,
+  mps.round_points,
+  mps.nb_respawns,
+  mps.respawn_times,
+  mps.best_time,
+  mps.cp_times,
+  mps.respawn_time_loss,
+  mps.nb_respawns_by_cp,
+  mps.created_at
+FROM
+  trackmania.match_player_stats mps
+  JOIN trackmania.scrims s ON s.id = mps.scrim_id
+  JOIN trackmania.players p ON p.id = mps.player_id
+  LEFT JOIN trackmania.maps maps ON maps.id = mps.map_id
+  LEFT JOIN sprocket.match_parent mp ON mp.id = s.sprocket_match_parent_id
+ORDER BY
+  mps.created_at DESC,
+  mps.scrim_id,
+  mps.map_id,
+  mps.team_id,
+  mps.points DESC;

--- a/queries/public/trackmania/rosters.sql
+++ b/queries/public/trackmania/rosters.sql
@@ -1,0 +1,33 @@
+SELECT
+  rs.id AS roster_slot_id,
+  t.id AS team_id,
+  t.name AS team_name,
+  f.id AS franchise_id,
+  f.name AS franchise_name,
+  f.code AS franchise_code,
+  gsg.id AS skill_group_id,
+  COALESCE(gsgp.description, gsgp.code) AS league,
+  rr.id AS roster_role_id,
+  rr.name AS roster_role_name,
+  rs."playerId" AS sprocket_player_id,
+  lp.id AS local_player_id,
+  lp.discord_id,
+  lp.discord_username,
+  lp.member_id,
+  lp.platform_account_ids
+FROM
+  sprocket.roster_slot rs
+  JOIN sprocket.team t ON t.id = rs."teamId"
+  JOIN sprocket.franchise f ON f.id = t."franchiseId"
+  JOIN sprocket.game_skill_group gsg ON gsg.id = t."skillGroupId"
+  JOIN sprocket.game g ON g.id = gsg."gameId"
+  LEFT JOIN sprocket.game_skill_group_profile gsgp ON gsgp."skillGroupId" = gsg.id
+  JOIN sprocket.roster_role rr ON rr.id = rs."roleId"
+  LEFT JOIN trackmania.players lp ON lp.sprocket_player_id = rs."playerId"
+WHERE
+  g.title = 'Trackmania'
+ORDER BY
+  league,
+  franchise_name,
+  roster_role_name,
+  roster_slot_id;


### PR DESCRIPTION
## Summary
Add public Trackmania dataset queries so LO and platform reviewers can verify matches, player stats, Elo, eligibility, and roster state from the published dataset pipeline.

## Context
The Trackmania platform implementation in `tm-q-bot` adds Sprocket identity mapping, fixture-aware scheduled matches, parser result ingestion, Elo history, and roster administration. Reviewers need corresponding public dataset queries to inspect those records independently without relying on bot commands.

## Changes
- Add `queries/public/trackmania/matches.sql` for local scrim, Sprocket match, fixture, schedule group, and game mode data.
- Add `queries/public/trackmania/player_stats.sql` for map/player stat rows with local and Sprocket player identity fields.
- Add `queries/public/trackmania/elo_ratings.sql` for current local Trackmania Elo ratings.
- Add `queries/public/trackmania/elo_history.sql` for per-scrim Elo changes and Sprocket match linkage.
- Add `queries/public/trackmania/eligibility.sql` for Sprocket eligibility rows joined back to local Trackmania players and scrims.
- Add `queries/public/trackmania/rosters.sql` for Trackmania Sprocket roster slots joined to local player identity data.

### Key Implementation Details
- Queries live under a dedicated `queries/public/trackmania/` namespace to avoid changing existing Rocket League/shared public queries.
- Queries are filtered to Trackmania through Sprocket game metadata where they read directly from Sprocket tables.
- Local Trackmania IDs and Sprocket IDs are exposed together so reviewers can correlate bot, parser, and Sprocket records.

## Use Cases
- Verify an LO test match's fixture linkage and Sprocket match IDs.
- Compare parser-written player stats against local players and Sprocket player IDs.
- Inspect Elo rating/history rows after match processing.
- Confirm eligibility points were written for the correct Sprocket players.
- Review roster slot state for Trackmania franchises and leagues.

## Testing
Review the queries in the dataset publication environment or run them against a database containing both `trackmania` and `sprocket` schemas.

Suggested smoke checks:

```sql
SELECT * FROM queries/public/trackmania/matches.sql;
SELECT * FROM queries/public/trackmania/player_stats.sql;
SELECT * FROM queries/public/trackmania/elo_ratings.sql;
SELECT * FROM queries/public/trackmania/elo_history.sql;
SELECT * FROM queries/public/trackmania/eligibility.sql;
SELECT * FROM queries/public/trackmania/rosters.sql;
```

## Links
- Companion bot PR: adds identity mapping, admin audit/backfill commands, parser hardening, fixture-aware scheduled matches, Elo inspection, and roster administration.
