### PR TITLE
Isolate query failures in publish pipeline (#45)

### DIFF
--- a/src/tasks/execute_and_upload_pg.py
+++ b/src/tasks/execute_and_upload_pg.py
@@ -1,4 +1,4 @@
-from prefect import task
+from prefect import task, get_run_logger
 from prefect.filesystems import RemoteFileSystem
 
 from utils.run_pg import run_pg
@@ -20,43 +20,38 @@ def execute_and_upload_pg(query: str,
     :param fs: Remote file system used for writing the file.
     :param formats: Formats to produce; parquet, csv, and json are supported
 
-    :return: The path of the uploaded file in the bucket.
+    :return: The path of the uploaded file in the bucket, or None if the query failed.
     """
-    results = run_pg(f"""
-    WITH ORIGINAL AS ({query})
-    SELECT current_timestamp as "as_of", ORIGINAL.* FROM ORIGINAL
-    """)
+    logger = get_run_logger()
 
+    try:
+        results = run_pg(f"""
+        WITH ORIGINAL AS ({query})
+        SELECT current_timestamp as "as_of", ORIGINAL.* FROM ORIGINAL
+        """)
 
-    if "parquet" in formats:
-        (parquet_path, close) = write_parquet(results)
+        if "parquet" in formats:
+            (parquet_path, close) = write_parquet(results)
+            with open(parquet_path, "rb") as f:
+                fs.write_path(destination_path + ".parquet", f.read())
+            if close:
+                close()
 
-        with open(parquet_path, "rb") as f:
-            fs.write_path(
-                destination_path + ".parquet",
-                f.read()
-            )
-        if close:
-            close()
+        if "csv" in formats:
+            (csv_path, close) = write_csv(results)
+            with open(csv_path, "rb") as f:
+                fs.write_path(destination_path + ".csv", f.read())
+            if close:
+                close()
 
-    if "csv" in formats:
-        (csv_path, close) = write_csv(results)
-        with open(csv_path, "rb") as f:
-            fs.write_path(
-                destination_path + ".csv",
-                f.read()
-            )
-        if close:
-            close()
+        if "json" in formats:
+            (json_path, close) = write_json(results)
+            with open(json_path, "rb") as f:
+                fs.write_path(destination_path + ".json", f.read())
+            if close:
+                close()
 
-    if "json" in formats:
-        (json_path, close) = write_json(results)
-        with open(json_path, "rb") as f:
-            fs.write_path(
-                destination_path + ".json",
-                f.read()
-            )
-        if close:
-            close()
-
-    return destination_path
+        return destination_path
+    except Exception as e:
+        logger.error(f"Failed to execute/upload query for {destination_path}: {e}")
+        return None


### PR DESCRIPTION
Closes #45. Catches exceptions in `execute_and_upload_pg` so a single failing query gets logged via Prefect's run logger instead of crashing the whole pipeline run. Since the page-building step already discovers files via an S3 glob rather than by inspecting task results, a failed query is simply skipped rather than blocking the archive/docs build for everything else.

Testing: verified locally end-to-end. Registered local Prefect blocks (S3 storage + DB secret) to fully exercise the flow, then ran it against a test query directory containing one deliberately broken query (that references a nonexistent table) alongside a valid one. 

Confirmed:
- The broken query fails with a real Postgres error, gets caught, and is logged via `logger.error`.
- Its task run reports `Completed`, not `Failed`, so downstream tasks waiting on it (`wait_for=data_futures`) are unaffected.
- The rest of the pipeline (archive creation, index/docs page build, S3 sync) completes normally, and the flow finishes in state `Completed`.

Side note, unrelated to this fix: found that `write_parquet.py`/`write_csv.py`/`write_json.py` all hit a Windows-specific file-locking error (`WinError 32`) due to how `tempfile.NamedTemporaryFile()` is used — works fine on Mac/Linux, breaks on Windows. Flagging separately since it’s out of scope here.
