### PR TITLE
Close Postgres connections on both success and failure paths (#104)

### DIFF
--- a/sql2datasets/src/sql2datasets/sql2csv.py
+++ b/sql2datasets/src/sql2datasets/sql2csv.py
@@ -65,6 +65,7 @@ def run_sql_script(
         psycopg2.Error: If database connection or query execution fails.
     """
     logger.info(f"  Executing SQL script: {file_path}")
+    connection = None
     try:
         # Connect to PostgreSQL database
         logger.info(
@@ -102,9 +103,6 @@ def run_sql_script(
         logger.debug("    Executing SQL script")
         df = pd.read_sql_query(sql_script, connection)
 
-        # Close connection
-        connection.close()
-
         logger.info("  SQL script executed successfully")
         return df
     except psycopg2.Error as e:
@@ -113,6 +111,9 @@ def run_sql_script(
     except Exception as e:
         logger.error(f"Error processing SQL script {file_path}: {e}")
         raise
+    finally:
+        if connection is not None:
+            connection.close()
 
 
 def upload_to_s3(file_name: str, file_path: str) -> None:

--- a/src/utils/run_pg.py
+++ b/src/utils/run_pg.py
@@ -6,8 +6,8 @@ from psycopg.rows import dict_row
 def run_pg(query: str):
     connstring = Secret.load("sprocket-main-ds-pg")
     info = psycopg.conninfo.make_conninfo(connstring.get())
-    conn = psycopg.connect(conninfo=info, row_factory=dict_row)
-    cursor = conn.cursor()
-    cursor.execute(query)
-    r = cursor.fetchall()
+    with psycopg.connect(conninfo=info, row_factory=dict_row) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(query)
+            r = cursor.fetchall()
     return r


### PR DESCRIPTION
Closes #104. Two connection leaks fixed:

`sql2csv.py`'s `run_sql_script()` only called `connection.close()` on the
success path if the query raised, execution jumped to the except block, and the connection was never closed. Now wrapped in a `finally` block.
(with a `None` guard, since `psycopg2.connect()` itself could fail before
`connection` is ever assigned, so it always closes, success or failure.

`run_pg.py`'s `run_pg()` never closed its connection at all. Rewritten to
Use `with` context managers for both the connection and the cursor, which
close automatically on exit regardless of outcome.

Testing: Verified locally end-to-end for both. Set up an isolated venv for
`sql2datasets` its dependencies conflicted with the main venv’s pinned
`aiobotocore`/`botocore` versions  used a separate `env-sql2datasets` to
avoid that going forward. For each fix, I ran both a real failing query and
a real successful query against the live database, then confirmed via
`pg_stat_activity`, the connection counts stayed flat afterward in both
cases, no leaked sessions on success or failure.